### PR TITLE
Remove duplicate margin rules

### DIFF
--- a/cerberus-hybrid.html
+++ b/cerberus-hybrid.html
@@ -108,11 +108,6 @@
                 margin-left: auto !important;
                 margin-right: auto !important;
             }
-            /* And center justify these ones. */
-            .fluid-centered {
-                margin-left: auto !important;
-                margin-right: auto !important;
-            }
 
             /* What it does: Forces table cells into full-width rows. */
             .stack-column,

--- a/cerberus-responsive.html
+++ b/cerberus-responsive.html
@@ -112,11 +112,6 @@
                 margin-left: auto !important;
                 margin-right: auto !important;
             }
-            /* And center justify these ones. */
-            .fluid-centered {
-                margin-left: auto !important;
-                margin-right: auto !important;
-            }
 
             /* What it does: Forces table cells into full-width rows. */
             .stack-column,


### PR DESCRIPTION
Whilst I'm completely new to the CSS email world, I can't see how these rules, duplicated above for `.fluid, .fluid-centered`, can't just go?

Also - lots of trailing whitespace in these files - happy to clean up and submit another PR if welcomed?
