### PR TITLE
Fix comment typo

### DIFF
--- a/cerberus-fluid.html
+++ b/cerberus-fluid.html
@@ -45,7 +45,7 @@
             -webkit-text-size-adjust: 100%;
         }
 
-        /* What is does: Centers email on Android 4.4 */
+        /* What it does: Centers email on Android 4.4 */
         div[style*="margin: 16px 0"] {
             margin:0 !important;
         }

--- a/cerberus-responsive.html
+++ b/cerberus-responsive.html
@@ -45,7 +45,7 @@
             -webkit-text-size-adjust: 100%;
         }
 
-        /* What is does: Centers email on Android 4.4 */
+        /* What it does: Centers email on Android 4.4 */
         div[style*="margin: 16px 0"] {
             margin:0 !important;
         }


### PR DESCRIPTION
"What is does" in fluid and responsive templates should be "What it does". 