### PR TITLE
update cerberus-hybrid.html

### DIFF
--- a/cerberus-fluid.html
+++ b/cerberus-fluid.html
@@ -152,7 +152,7 @@
 	<![endif]-->
 
 </head>
-<body width="100%" bgcolor="#222222" style="margin: 0; mso-line-height-rule: exactly;">
+<body width="100%" bgcolor="#222222" style="margin: 0; mso-line-height-rule: exactly; font-family: sans-serif; font-weight:normal; line-height: 1.2;">
 	<center style="width: 100%; background: #222222; text-align: left;">
 
 		<!-- Visually Hidden Preheader Text : BEGIN -->

--- a/cerberus-hybrid.html
+++ b/cerberus-hybrid.html
@@ -185,7 +185,7 @@
     <![endif]-->
 
 </head>
-<body width="100%" bgcolor="#222222" style="margin: 0; mso-line-height-rule: exactly; font-family: sans-serif;">
+<body width="100%" bgcolor="#222222" style="margin: 0; mso-line-height-rule: exactly; font-family: sans-serif; font-weight:normal; line-height: 1.2;">
     <center style="width: 100%; background: #222222; text-align: left;">
 
         <!-- Visually Hidden Preheader Text : BEGIN -->

--- a/cerberus-hybrid.html
+++ b/cerberus-hybrid.html
@@ -185,7 +185,7 @@
     <![endif]-->
 
 </head>
-<body width="100%" bgcolor="#222222" style="margin: 0; mso-line-height-rule: exactly;">
+<body width="100%" bgcolor="#222222" style="margin: 0; mso-line-height-rule: exactly; font-family: sans-serif;">
     <center style="width: 100%; background: #222222; text-align: left;">
 
         <!-- Visually Hidden Preheader Text : BEGIN -->

--- a/cerberus-responsive.html
+++ b/cerberus-responsive.html
@@ -190,7 +190,7 @@
 	<![endif]-->
 
 </head>
-<body width="100%" bgcolor="#222222" style="margin: 0; mso-line-height-rule: exactly;">
+<body width="100%" bgcolor="#222222" style="margin: 0; mso-line-height-rule: exactly; font-family: sans-serif; font-weight:normal; line-height: 1.2;">
 	<center style="width: 100%; background: #222222; text-align: left;">
 
 		<!-- Visually Hidden Preheader Text : BEGIN -->


### PR DESCRIPTION
The data detectors overrides are inheriting browser base styles for the footer. This update adds sans-serif to the body so that the inherited font styles are sans-serif in contexts they might not otherwise be.