### PR TITLE
Modified divs to remove extra margins in Outlook and Windows 10 Mail

### DIFF
--- a/cerberus-fluid.html
+++ b/cerberus-fluid.html
@@ -215,7 +215,7 @@
             1. max-width for all clients except Desktop Windows Outlook, allowing the email to squish on narrow but never go wider than 600px.
             2. MSO tags for Desktop Windows Outlook enforce a 600px width.
         -->
-        <div style="max-width: 600px; margin: auto;" class="email-container">
+        <div style="max-width: 600px; margin: 0 auto;" class="email-container">
             <!--[if mso]>
             <table align="center" role="presentation" cellspacing="0" cellpadding="0" border="0" width="600">
             <tr>
@@ -368,7 +368,7 @@
         <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%" style="background-color: #709f2b;">
             <tr>
                 <td valign="top">
-                    <div style="max-width: 600px; margin: auto;" class="email-container">
+                    <div style="max-width: 600px; margin: 0 auto;" class="email-container">
                         <!--[if mso]>
                         <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="600">
                         <tr>

--- a/cerberus-hybrid.html
+++ b/cerberus-hybrid.html
@@ -249,7 +249,7 @@
             2. MSO tags for Desktop Windows Outlook enforce a 680px width.
             Note: The Fluid and Responsive templates have a different width (600px). The hybrid grid is more "fragile", and I've found that 680px is a good width. Change with caution.
         -->
-        <div style="max-width: 680px; margin: auto;" class="email-container">
+        <div style="max-width: 680px; margin: 0 auto;" class="email-container">
             <!--[if mso]>
             <table align="center" role="presentation" cellspacing="0" cellpadding="0" border="0" width="680">
             <tr>
@@ -705,7 +705,7 @@
         <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%" style="background-color: #709f2b;">
             <tr>
                 <td valign="top">
-                    <div style="max-width: 680px; margin: auto;" class="email-container">
+                    <div style="max-width: 680px; margin: 0 auto;" class="email-container">
                         <!--[if mso]>
                         <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="680">
                         <tr>

--- a/cerberus-responsive.html
+++ b/cerberus-responsive.html
@@ -556,7 +556,7 @@
 	    <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%" style="background-color: #709f2b;">
 	        <tr>
 	            <td valign="top">
-	                <div style="max-width: 600px; margin: auto;" class="email-container">
+	                <div style="max-width: 600px; margin: 0 auto;" class="email-container">
 	                    <!--[if mso]>
 	                    <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="600">
 	                    <tr>


### PR DESCRIPTION
Modified vertical margins of all instances of div.email-container to 'margin: 0 auto;' to remove top and bottom margins (about 6px above, and 6px below at 100% zoom) in Windows 10 Mail (Win 10) and also Outlook 2007, 2010, 2013, 2016 (all on Win 7). Issue confirmed via Litmus only.

Original cerberus-hybrid.html top in Outlook 2016 (Win 7): 
![ol2016-vertical-allowed-1366_png__1366x3464_](https://user-images.githubusercontent.com/819964/39857612-caf62958-53e8-11e8-96ff-a1202c20334f.png)
Updated cerberus-hybrid.html top in Outlook 2016 (Win 7): 
![ol2016-vertical-allowed-1366_png__1366x3451_](https://user-images.githubusercontent.com/819964/39857613-cb4cff58-53e8-11e8-86d1-d5a05c58550c.png)

Issue discovered while attempting table background-color manipulation.
