### PR TITLE
Add display:block to negate extra space beneath hero images

### DIFF
--- a/cerberus-fluid.html
+++ b/cerberus-fluid.html
@@ -221,7 +221,7 @@
                 <!-- Hero Image, Flush : BEGIN -->
                 <tr>
                     <td style="background-color: #ffffff;">
-                        <img src="https://via.placeholder.com/1200x600" width="600" height="" alt="alt_text" border="0" style="width: 100%; max-width: 600px; height: auto; background: #dddddd; font-family: sans-serif; font-size: 15px; line-height: 15px; color: #555555; margin: auto;" class="g-img">
+                        <img src="https://via.placeholder.com/1200x600" width="600" height="" alt="alt_text" border="0" style="width: 100%; max-width: 600px; height: auto; background: #dddddd; font-family: sans-serif; font-size: 15px; line-height: 15px; color: #555555; margin: auto; display: block;" class="g-img">
                     </td>
                 </tr>
                 <!-- Hero Image, Flush : END -->

--- a/cerberus-hybrid.html
+++ b/cerberus-hybrid.html
@@ -254,7 +254,7 @@
 	            <!-- Hero Image, Flush : BEGIN -->
                 <tr>
                     <td style="background-color: #ffffff;">
-                        <img src="https://via.placeholder.com/1360x600" width="680" height="" alt="alt_text" border="0" style="width: 100%; max-width: 680px; height: auto; background: #dddddd; font-family: sans-serif; font-size: 15px; line-height: 15px; color: #555555; margin: auto;" class="fluid g-img">
+                        <img src="https://via.placeholder.com/1360x600" width="680" height="" alt="alt_text" border="0" style="width: 100%; max-width: 680px; height: auto; background: #dddddd; font-family: sans-serif; font-size: 15px; line-height: 15px; color: #555555; margin: auto; display: block;" class="fluid g-img">
                     </td>
                 </tr>
                 <!-- Hero Image, Flush : END -->

--- a/cerberus-responsive.html
+++ b/cerberus-responsive.html
@@ -245,7 +245,7 @@
             <!-- Hero Image, Flush : BEGIN -->
             <tr>
                 <td style="background-color: #ffffff;">
-                    <img src="https://via.placeholder.com/1200x600" width="600" height="" alt="alt_text" border="0" style="width: 100%; max-width: 600px; height: auto; background: #dddddd; font-family: sans-serif; font-size: 15px; line-height: 15px; color: #555555; margin: auto;" class="g-img">
+                    <img src="https://via.placeholder.com/1200x600" width="600" height="" alt="alt_text" border="0" style="width: 100%; max-width: 600px; height: auto; background: #dddddd; font-family: sans-serif; font-size: 15px; line-height: 15px; color: #555555; margin: auto; display: block;" class="g-img">
                 </td>
             </tr>
             <!-- Hero Image, Flush : END -->


### PR DESCRIPTION
There is extra space in the `<td>` beneath the hero image in each template:

![screen shot 2019-02-05 at 10 01 58 pm](https://user-images.githubusercontent.com/1172461/52318420-6b14cc80-2992-11e9-951e-e4053bd1d709.png)

---

Adding `display:block;` to the image takes it away.

This fixes #204 