### PR TITLE
Replace % with px for hybrid widths

### DIFF
--- a/cerberus-hybrid.html
+++ b/cerberus-hybrid.html
@@ -414,7 +414,7 @@
                                     <tr>
                                     <td valign="top" width="220">
                                     <![endif]-->
-                                    <div style="display:inline-block; margin: 0 -2px; max-width:33.33%; min-width:220px; vertical-align:top; width:100%;" class="stack-column">
+                                    <div style="display:inline-block; margin: 0 -2px; max-width: 220px; min-width:160px; vertical-align:top; width:100%;" class="stack-column">
                                         <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%">
                                             <tr>
                                                 <td style="padding: 10px;">
@@ -438,7 +438,7 @@
                                     </td>
                                     <td valign="top" width="220">
                                     <![endif]-->
-                                    <div style="display:inline-block; margin: 0 -2px; max-width:33.33%; min-width:220px; vertical-align:top; width:100%;" class="stack-column">
+                                    <div style="display:inline-block; margin: 0 -2px; max-width: 220px; min-width:160px; vertical-align:top; width:100%;" class="stack-column">
                                         <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%">
                                             <tr>
                                                 <td style="padding: 10px;">
@@ -462,7 +462,7 @@
                                     </td>
                                     <td valign="top" width="220">
                                     <![endif]-->
-                                    <div style="display:inline-block; margin: 0 -2px; max-width:33.33%; min-width:220px; vertical-align:top; width:100%;" class="stack-column">
+                                    <div style="display:inline-block; margin: 0 -2px; max-width: 220px; min-width:160px; vertical-align:top; width:100%;" class="stack-column">
                                         <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%">
                                             <tr>
                                                 <td style="padding: 10px;">
@@ -529,7 +529,7 @@
                                     </td>
                                     <td valign="top" width="440" style="width: 440px;">
                                     <![endif]-->
-                                    <div style="display:inline-block; margin: 0 -2px; max-width:66.66%; min-width:320px; vertical-align:top;" class="stack-column">
+                                    <div style="display:inline-block; margin: 0 -2px; max-width: 440px; min-width:320px; vertical-align:top;" class="stack-column">
                                         <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%">
                                             <tr>
                                                 <td dir="ltr" style="font-family: sans-serif; font-size: 15px; line-height: 20px; color: #555555; padding: 10px 10px 0; text-align: left;" class="center-on-narrow">
@@ -595,7 +595,7 @@
                                     </td>
                                     <td valign="top" width="440" style="width: 440px;">
                                     <![endif]-->
-                                    <div style="display:inline-block; margin: 0 -2px; max-width:66.66%; min-width:320px; vertical-align:top;" class="stack-column">
+                                    <div style="display:inline-block; margin: 0 -2px; max-width: 440px; min-width:320px; vertical-align:top;" class="stack-column">
                                         <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%">
                                             <tr>
                                                 <td dir="ltr" style="font-family: sans-serif; font-size: 15px; line-height: 20px; color: #555555; padding: 10px 10px 0; text-align: left;" class="center-on-narrow">


### PR DESCRIPTION
This PR resolves the inconsistencies in defining hybrid widths using both `%` and `px`. I've standardized on using `px`, so this converts all `%` to pixels.

---

This resolves #215 