### PR TITLE
Fix responsive columns stacking in iOS Outlook

### DIFF
--- a/cerberus-responsive.html
+++ b/cerberus-responsive.html
@@ -58,6 +58,11 @@
             mso-table-rspace: 0pt !important;
         }
 
+        /* What it does: Replaces default bold style. */
+        th {
+        	font-weight: normal;
+        }
+
         /* What it does: Fixes webkit padding issue. */
         table {
             border-spacing: 0 !important;
@@ -221,7 +226,7 @@
         <!-- Create white space after the desired preview text so email clients don’t pull other distracting text into the inbox preview. Extend as necessary. -->
         <!-- Preview Text Spacing Hack : BEGIN -->
         <div style="display: none; font-size: 1px; line-height: 1px; max-height: 0px; max-width: 0px; opacity: 0; overflow: hidden; mso-hide: all; font-family: sans-serif;">
-	        &zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;
+            &zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;
         </div>
         <!-- Preview Text Spacing Hack : END -->
 
@@ -309,7 +314,7 @@
 	                <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%">
 	                    <tr>
 	                        <!-- Column : BEGIN -->
-	                        <td valign="top" width="50%" class="stack-column-center">
+	                        <th valign="top" width="50%" class="stack-column-center">
 	                            <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%">
 	                                <tr>
 	                                    <td style="padding: 10px; text-align: center">
@@ -322,10 +327,10 @@
 	                                    </td>
 	                                </tr>
 	                            </table>
-	                        </td>
+	                        </th>
 	                        <!-- Column : END -->
 	                        <!-- Column : BEGIN -->
-	                        <td valign="top" width="50%" class="stack-column-center">
+	                        <th valign="top" width="50%" class="stack-column-center">
 	                            <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%">
 	                                <tr>
 	                                    <td style="padding: 10px; text-align: center">
@@ -338,7 +343,7 @@
 	                                    </td>
 	                                </tr>
 	                            </table>
-	                        </td>
+	                        </th>
 	                        <!-- Column : END -->
 	                    </tr>
 	                </table>
@@ -352,7 +357,7 @@
 	                <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%">
 	                    <tr>
 	                        <!-- Column : BEGIN -->
-	                        <td valign="top" width="33.33%" class="stack-column-center">
+	                        <th valign="top" width="33.33%" class="stack-column-center">
 	                            <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%">
 	                                <tr>
 	                                    <td style="padding: 10px; text-align: center">
@@ -365,10 +370,10 @@
 	                                    </td>
 	                                </tr>
 	                            </table>
-	                        </td>
+	                        </th>
 	                        <!-- Column : END -->
 	                        <!-- Column : BEGIN -->
-	                        <td valign="top" width="33.33%" class="stack-column-center">
+	                        <th valign="top" width="33.33%" class="stack-column-center">
 	                            <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%">
 	                                <tr>
 	                                    <td style="padding: 10px; text-align: center">
@@ -381,10 +386,10 @@
 	                                    </td>
 	                                </tr>
 	                            </table>
-	                        </td>
+	                        </th>
 	                        <!-- Column : END -->
 	                        <!-- Column : BEGIN -->
-	                        <td valign="top" width="33.33%" class="stack-column-center">
+	                        <th valign="top" width="33.33%" class="stack-column-center">
 	                            <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%">
 	                                <tr>
 	                                    <td style="padding: 10px; text-align: center">
@@ -397,7 +402,7 @@
 	                                    </td>
 	                                </tr>
 	                            </table>
-	                        </td>
+	                        </th>
 	                        <!-- Column : END -->
 	                    </tr>
 	                </table>
@@ -411,7 +416,7 @@
 	                <table role="presentation" border="0" cellpadding="0" cellspacing="0" width="100%">
 	                    <tr>
 	                        <!-- Column : BEGIN -->
-	                        <td width="33.33%" class="stack-column-center">
+	                        <th width="33.33%" class="stack-column-center">
 	                            <table role="presentation" border="0" cellpadding="0" cellspacing="0" width="100%">
 	                                <tr>
 	                                    <td dir="ltr" valign="top" style="padding: 0 10px;">
@@ -419,10 +424,10 @@
 	                                    </td>
 	                                </tr>
 	                            </table>
-	                        </td>
+	                        </th>
 	                        <!-- Column : END -->
 	                        <!-- Column : BEGIN -->
-	                        <td width="66.66%" class="stack-column-center">
+	                        <th width="66.66%" class="stack-column-center">
 	                            <table role="presentation" border="0" cellpadding="0" cellspacing="0" width="100%">
 	                                <tr>
 	                                    <td dir="ltr" valign="top" style="font-family: sans-serif; font-size: 15px; line-height: 20px; color: #555555; padding: 10px; text-align: left;" class="center-on-narrow">
@@ -440,7 +445,7 @@
 	                                    </td>
 	                                </tr>
 	                            </table>
-	                        </td>
+	                        </th>
 	                        <!-- Column : END -->
 	                    </tr>
 	                </table>
@@ -454,7 +459,7 @@
 	                <table role="presentation" border="0" cellpadding="0" cellspacing="0" width="100%">
 	                    <tr>
 	                        <!-- Column : BEGIN -->
-	                        <td width="33.33%" class="stack-column-center">
+	                        <th width="33.33%" class="stack-column-center">
 	                            <table role="presentation" border="0" cellpadding="0" cellspacing="0" width="100%">
 	                                <tr>
 	                                    <td dir="ltr" valign="top" style="padding: 0 10px;">
@@ -462,10 +467,10 @@
 	                                    </td>
 	                                </tr>
 	                            </table>
-	                        </td>
+	                        </th>
 	                        <!-- Column : END -->
 	                        <!-- Column : BEGIN -->
-	                        <td width="66.66%" class="stack-column-center">
+	                        <th width="66.66%" class="stack-column-center">
 	                            <table role="presentation" border="0" cellpadding="0" cellspacing="0" width="100%">
 	                                <tr>
 	                                    <td dir="ltr" valign="top" style="font-family: sans-serif; font-size: 15px; line-height: 20px; color: #555555; padding: 10px; text-align: left;" class="center-on-narrow">
@@ -483,7 +488,7 @@
 	                                    </td>
 	                                </tr>
 	                            </table>
-	                        </td>
+	                        </th>
 	                        <!-- Column : END -->
 	                    </tr>
 	                </table>


### PR DESCRIPTION
This PR resolves #226, forcing the media queries in the responsive template to work in iOS Outlook by changing the `<td>`'s with responsive classes to `<th>`'s.