### PR TITLE
Adds css selectors that force samsung email clients to use 100% width

### DIFF
--- a/cerberus-fluid.html
+++ b/cerberus-fluid.html
@@ -34,7 +34,7 @@
         /* Beware: It can remove the padding / margin and add a background color to the compose a reply window. */
         html,
         body {
-            margin: 0 !important;
+            margin: 0 auto !important;
             padding: 0 !important;
             height: 100% !important;
             width: 100% !important;
@@ -49,6 +49,11 @@
         /* What it does: Centers email on Android 4.4 */
         div[style*="margin: 16px 0"] {
             margin: 0 !important;
+        }
+
+        /* What it does: forces Samsung Android mail clients to use the entire viewport */
+        #MessageViewBody, #MessageWebViewDiv{
+            width: 100% !important;
         }
 
         /* What it does: Stops Outlook from adding extra spacing to tables. */

--- a/cerberus-hybrid.html
+++ b/cerberus-hybrid.html
@@ -34,7 +34,7 @@
         /* Beware: It can remove the padding / margin and add a background color to the compose a reply window. */
         html,
         body {
-            margin: 0 !important;
+            margin: 0 auto !important;
             padding: 0 !important;
             height: 100% !important;
             width: 100% !important;
@@ -49,6 +49,10 @@
         /* What it does: Centers email on Android 4.4 */
         div[style*="margin: 16px 0"] {
             margin: 0 !important;
+        }
+        /* What it does: forces Samsung Android mail clients to use the entire viewport */
+        #MessageViewBody, #MessageWebViewDiv{
+            width: 100% !important;
         }
 
         /* What it does: Stops Outlook from adding extra spacing to tables. */

--- a/cerberus-responsive.html
+++ b/cerberus-responsive.html
@@ -34,7 +34,7 @@
         /* Beware: It can remove the padding / margin and add a background color to the compose a reply window. */
         html,
         body {
-            margin: 0 !important;
+            margin: 0 auto !important;
             padding: 0 !important;
             height: 100% !important;
             width: 100% !important;
@@ -49,6 +49,11 @@
         /* What it does: Centers email on Android 4.4 */
         div[style*="margin: 16px 0"] {
             margin: 0 !important;
+        }
+
+        /* What it does: forces Samsung Android mail clients to use the entire viewport */
+        #MessageViewBody, #MessageWebViewDiv{
+            width: 100% !important;
         }
 
         /* What it does: Stops Outlook from adding extra spacing to tables. */


### PR DESCRIPTION
Hi Ted, while debugging some emails I built using your templates I found some fixes that fixed issues with Samsung clients for me.

Before Samsung clients wouldn't respect width and margin values:

![image](https://user-images.githubusercontent.com/37232811/69681188-6841be80-1101-11ea-9317-3ce3bdc52526.png)

By adding both Samsung specific id selectors, and adding margin: 0 auto !important for the body css selector you can ensure that Samsung clients respect width and margin values

![image](https://user-images.githubusercontent.com/37232811/69681266-ac34c380-1101-11ea-8cea-b10fc75a64f0.png)


On one email I just had to add the id selectors, on the other I had to add margin 0 auto

https://litmus.com/community/discussions/7133-samsung-mail-100-width-fix-for-left-aligned-mails