### PR TITLE
Make footer text color white

### DIFF
--- a/cerberus-fluid.html
+++ b/cerberus-fluid.html
@@ -345,12 +345,12 @@
             <!-- Email Footer : BEGIN -->
 	        <table align="center" role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%" style="margin: auto;">
                 <tr>
-                    <td style="padding: 20px; font-family: sans-serif; font-size: 12px; line-height: 15px; text-align: center; color: #888888;">
-                        <webversion style="color: #cccccc; text-decoration: underline; font-weight: bold;">View as a Web Page</webversion>
+                    <td style="padding: 20px; font-family: sans-serif; font-size: 12px; line-height: 15px; text-align: center; color: #ffffff;">
+                        <webversion style="color: #ffffff; text-decoration: underline; font-weight: bold;">View as a Web Page</webversion>
                         <br><br>
 						Company Name<br><span class="unstyle-auto-detected-links">123 Fake Street, SpringField, OR, 97477 US<br>(123) 456-7890</span>
                         <br><br>
-                        <unsubscribe style="color: #888888; text-decoration: underline;">unsubscribe</unsubscribe>
+                        <unsubscribe style="color: #ffffff; text-decoration: underline;">unsubscribe</unsubscribe>
                     </td>
                 </tr>
             </table>

--- a/cerberus-hybrid.html
+++ b/cerberus-hybrid.html
@@ -607,12 +607,12 @@
             <!-- Email Footer : BEGIN -->
             <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%" style="max-width: 680px;">
                 <tr>
-                    <td style="padding: 20px; font-family: sans-serif; font-size: 12px; line-height: 15px; text-align: center; color: #888888;">
-                        <webversion style="color: #cccccc; text-decoration: underline; font-weight: bold;">View as a Web Page</webversion>
+                    <td style="padding: 20px; font-family: sans-serif; font-size: 12px; line-height: 15px; text-align: center; color: #ffffff;">
+                        <webversion style="color: #ffffff; text-decoration: underline; font-weight: bold;">View as a Web Page</webversion>
                         <br><br>
 		                Company Name<br><span class="unstyle-auto-detected-links">123 Fake Street, SpringField, OR, 97477 US<br>(123) 456-7890</span>
                         <br><br>
-                        <unsubscribe style="color: #888888; text-decoration: underline;">unsubscribe</unsubscribe>
+                        <unsubscribe style="color: #ffffff; text-decoration: underline;">unsubscribe</unsubscribe>
                     </td>
                 </tr>
             </table>

--- a/cerberus-responsive.html
+++ b/cerberus-responsive.html
@@ -536,12 +536,12 @@
 	    <!-- Email Footer : BEGIN -->
         <table align="center" role="presentation" cellspacing="0" cellpadding="0" border="0" width="600" style="margin: auto;" class="email-container">
 	        <tr>
-	            <td style="padding: 20px; font-family: sans-serif; font-size: 12px; line-height: 15px; text-align: center; color: #888888;">
-	                <webversion style="color: #cccccc; text-decoration: underline; font-weight: bold;">View as a Web Page</webversion>
+	            <td style="padding: 20px; font-family: sans-serif; font-size: 12px; line-height: 15px; text-align: center; color: #ffffff;">
+	                <webversion style="color: #ffffff; text-decoration: underline; font-weight: bold;">View as a Web Page</webversion>
 	                <br><br>
 	                Company Name<br><span class="unstyle-auto-detected-links">123 Fake Street, SpringField, OR, 97477 US<br>(123) 456-7890</span>
 	                <br><br>
-	                <unsubscribe style="color: #888888; text-decoration: underline;">unsubscribe</unsubscribe>
+	                <unsubscribe style="color: #ffffff; text-decoration: underline;">unsubscribe</unsubscribe>
 	            </td>
 	        </tr>
 	    </table>


### PR DESCRIPTION
While these templates are not meant to be modified, it's best to set a good example for accessible email. So let's update the footer text color to pass AAA.

Fixes #243 