### PR TITLE
Added padding to Hero Image

### DIFF
--- a/cerberus-responsive.html
+++ b/cerberus-responsive.html
@@ -254,7 +254,7 @@
 
             <!-- Hero Image, Flush : BEGIN -->
             <tr>
-                <td style="background-color: #ffffff;">
+                <td style="padding: 20px 0; background-color: #ffffff;">
                     <img src="https://via.placeholder.com/1200x600" width="600" height="" alt="alt_text" border="0" style="width: 100%; max-width: 600px; height: auto; background: #dddddd; font-family: sans-serif; font-size: 15px; line-height: 15px; color: #555555; margin: auto; display: block;" class="g-img">
                 </td>
             </tr>


### PR DESCRIPTION
Without padding, the hero image was offsetting to the left of the column text that followed, specifically in Microsoft Outlook on PC. Adding 0px padding aligns well with the column text below the hero image.