### PR TITLE
Improve email forwarding

### DIFF
--- a/cerberus-fluid.html
+++ b/cerberus-fluid.html
@@ -87,7 +87,7 @@
             border-collapse: collapse !important;
             margin: 0 auto !important;
         }
-        /* What it does: Prevents Mailchimp from inlining these styles. */
+        /* What it does: Prevents styles from being inlined. */
         @media all {
             table {
                 table-layout: fixed !important;
@@ -104,18 +104,21 @@
             text-decoration: none;
         }
 
-        /* What it does: A work-around for email clients meddling in triggered links. */
-        a[x-apple-data-detectors],  /* iOS */
-        .unstyle-auto-detected-links a,
-        .aBn {
-            border-bottom: 0 !important;
-            cursor: default !important;
-            color: inherit !important;
-            text-decoration: none !important;
-            font-size: inherit !important;
-            font-family: inherit !important;
-            font-weight: inherit !important;
-            line-height: inherit !important;
+        /* What it does: Prevents styles from being inlined. */
+        @media all {
+            /* What it does: A work-around for email clients meddling in triggered links. */
+            a[x-apple-data-detectors],  /* iOS */
+            .unstyle-auto-detected-links a,
+            .aBn {
+                border-bottom: 0 !important;
+                cursor: default !important;
+                color: inherit !important;
+                text-decoration: none !important;
+                font-size: inherit !important;
+                font-family: inherit !important;
+                font-weight: inherit !important;
+                line-height: inherit !important;
+            }
         }
 
         /* What it does: Prevents Gmail from displaying a download button on large, non-linked images. */
@@ -167,11 +170,14 @@
 	    .button-a {
 	        transition: all 100ms ease-in;
 	    }
-	    .button-td-primary:hover,
-	    .button-a-primary:hover {
-	        background: #555555 !important;
-	        border-color: #555555 !important;
-	    }
+        /* What it does: Prevents styles from being inlined. */
+        @media all {
+    	    .button-td-primary:hover,
+    	    .button-a-primary:hover {
+    	        background: #555555 !important;
+    	        border-color: #555555 !important;
+    	    }
+        }
 
 	    /* Media Queries */
 	    @media screen and (max-width: 600px) {

--- a/cerberus-fluid.html
+++ b/cerberus-fluid.html
@@ -85,8 +85,13 @@
         table {
             border-spacing: 0 !important;
             border-collapse: collapse !important;
-            table-layout: fixed !important;
             margin: 0 auto !important;
+        }
+        /* What it does: Prevents Mailchimp from inlining these styles. */
+        @media all {
+            table {
+                table-layout: fixed !important;
+            }
         }
 
         /* What it does: Uses a better rendering method when resizing images in IE. */

--- a/cerberus-hybrid.html
+++ b/cerberus-hybrid.html
@@ -84,8 +84,13 @@
         table {
             border-spacing: 0 !important;
             border-collapse: collapse !important;
-            table-layout: fixed !important;
             margin: 0 auto !important;
+        }
+        /* What it does: Prevents Mailchimp from inlining these styles. */
+        @media all {
+            table {
+                table-layout: fixed !important;
+            }
         }
 
         /* What it does: Uses a better rendering method when resizing images in IE. */

--- a/cerberus-hybrid.html
+++ b/cerberus-hybrid.html
@@ -86,7 +86,7 @@
             border-collapse: collapse !important;
             margin: 0 auto !important;
         }
-        /* What it does: Prevents Mailchimp from inlining these styles. */
+        /* What it does: Prevents styles from being inlined. */
         @media all {
             table {
                 table-layout: fixed !important;
@@ -103,18 +103,21 @@
             text-decoration: none;
         }
 
-        /* What it does: A work-around for email clients meddling in triggered links. */
-        a[x-apple-data-detectors],  /* iOS */
-        .unstyle-auto-detected-links a,
-        .aBn {
-            border-bottom: 0 !important;
-            cursor: default !important;
-            color: inherit !important;
-            text-decoration: none !important;
-            font-size: inherit !important;
-            font-family: inherit !important;
-            font-weight: inherit !important;
-            line-height: inherit !important;
+        /* What it does: Prevents styles from being inlined. */
+        @media all {
+            /* What it does: A work-around for email clients meddling in triggered links. */
+            a[x-apple-data-detectors],  /* iOS */
+            .unstyle-auto-detected-links a,
+            .aBn {
+                border-bottom: 0 !important;
+                cursor: default !important;
+                color: inherit !important;
+                text-decoration: none !important;
+                font-size: inherit !important;
+                font-family: inherit !important;
+                font-weight: inherit !important;
+                line-height: inherit !important;
+            }
         }
 
         /* What it does: Prevents Gmail from changing the text color in conversation threads. */
@@ -165,11 +168,14 @@
 	    .button-a {
 	        transition: all 100ms ease-in;
 	    }
-	    .button-td-primary:hover,
-	    .button-a-primary:hover {
-	        background: #555555 !important;
-	        border-color: #555555 !important;
-	    }
+        /* What it does: Prevents styles from being inlined. */
+        @media all {
+    	    .button-td-primary:hover,
+    	    .button-a-primary:hover {
+    	        background: #555555 !important;
+    	        border-color: #555555 !important;
+    	    }
+        }
 
 	    /* Media Queries */
 	    @media screen and (max-width: 480px) {

--- a/cerberus-responsive.html
+++ b/cerberus-responsive.html
@@ -92,7 +92,7 @@
             border-collapse: collapse !important;
             margin: 0 auto !important;
         }
-        /* What it does: Prevents Mailchimp from inlining these styles. */
+        /* What it does: Prevents styles from being inlined. */
         @media all {
             table {
                 table-layout: fixed !important;
@@ -109,18 +109,21 @@
             -ms-interpolation-mode:bicubic;
         }
 
-        /* What it does: A work-around for email clients meddling in triggered links. */
-        a[x-apple-data-detectors],  /* iOS */
-        .unstyle-auto-detected-links a,
-        .aBn {
-            border-bottom: 0 !important;
-            cursor: default !important;
-            color: inherit !important;
-            text-decoration: none !important;
-            font-size: inherit !important;
-            font-family: inherit !important;
-            font-weight: inherit !important;
-            line-height: inherit !important;
+        /* What it does: Prevents styles from being inlined. */
+        @media all {
+            /* What it does: A work-around for email clients meddling in triggered links. */
+            a[x-apple-data-detectors],  /* iOS */
+            .unstyle-auto-detected-links a,
+            .aBn {
+                border-bottom: 0 !important;
+                cursor: default !important;
+                color: inherit !important;
+                text-decoration: none !important;
+                font-size: inherit !important;
+                font-family: inherit !important;
+                font-weight: inherit !important;
+                line-height: inherit !important;
+            }
         }
 
         /* What it does: Prevents Gmail from changing the text color in conversation threads. */
@@ -171,11 +174,14 @@
         .button-a {
             transition: all 100ms ease-in;
         }
-	    .button-td-primary:hover,
-	    .button-a-primary:hover {
-	        background: #555555 !important;
-	        border-color: #555555 !important;
-	    }
+        /* What it does: Prevents styles from being inlined. */
+        @media all {
+    	    .button-td-primary:hover,
+    	    .button-a-primary:hover {
+    	        background: #555555 !important;
+    	        border-color: #555555 !important;
+    	    }
+        }
 
         /* Media Queries */
         @media screen and (max-width: 600px) {

--- a/cerberus-responsive.html
+++ b/cerberus-responsive.html
@@ -90,8 +90,13 @@
         table {
             border-spacing: 0 !important;
             border-collapse: collapse !important;
-            table-layout: fixed !important;
             margin: 0 auto !important;
+        }
+        /* What it does: Prevents Mailchimp from inlining these styles. */
+        @media all {
+            table {
+                table-layout: fixed !important;
+            }
         }
 
         /* What it does: Prevents Windows 10 Mail from underlining links despite inline CSS. Styles for underlined links should be inline. */


### PR DESCRIPTION
This PR attempts to improve Cerberus's rendering in Gmail after it's forwarded. #264 and #262 both report issues with the templates' rendering when forwarded. @maxackerman pointed out [this nifty trick](https://github.com/leemunroe/responsive-html-email-template/blob/master/email.html#L296) by Lee Munroe that prevents ESPs from inlining certain CSS properties, which seems to be the cause of the email breakage when forwarding.

I haven't fully tested this in Gmail, but adding it doesn't seem to cause any regression.

@maxackerman @marcelgruber would you be willing to help test this?