### PR TITLE
Remove <o:AllowPNG/> as not needed any more.

### DIFF
--- a/cerberus-fluid.html
+++ b/cerberus-fluid.html
@@ -14,7 +14,6 @@
     <!--[if gte mso 9]>
     <xml>
         <o:OfficeDocumentSettings>
-            <o:AllowPNG/>
             <o:PixelsPerInch>96</o:PixelsPerInch>
         </o:OfficeDocumentSettings>
     </xml>

--- a/cerberus-fluid.html
+++ b/cerberus-fluid.html
@@ -8,7 +8,7 @@
     <meta name="format-detection" content="telephone=no,address=no,email=no,date=no,url=no"> <!-- Tell iOS not to automatically link certain text strings. -->
     <meta name="color-scheme" content="light">
     <meta name="supported-color-schemes" content="light">
-    <title></title> <!--   The title tag shows in email notifications, like Android 4.4. -->
+    <title></title> <!-- The title tag shows in email notifications, like Android 4.4. -->
 
     <!-- What it does: Makes background images in 72ppi Outlook render at correct size. -->
     <!--[if gte mso 9]>

--- a/cerberus-hybrid.html
+++ b/cerberus-hybrid.html
@@ -14,7 +14,6 @@
     <!--[if gte mso 9]>
     <xml>
         <o:OfficeDocumentSettings>
-            <o:AllowPNG/>
             <o:PixelsPerInch>96</o:PixelsPerInch>
         </o:OfficeDocumentSettings>
     </xml>

--- a/cerberus-responsive.html
+++ b/cerberus-responsive.html
@@ -14,7 +14,6 @@
     <!--[if gte mso 9]>
     <xml>
         <o:OfficeDocumentSettings>
-            <o:AllowPNG/>
             <o:PixelsPerInch>96</o:PixelsPerInch>
         </o:OfficeDocumentSettings>
     </xml>


### PR DESCRIPTION
As discussed in this [Thread](https://emailgeeks.slack.com/archives/C1Z733K1P/p1641574872025400 ) on emailgeeks slack it is not needed any more.
