### PR TITLE
Fix random border in Outlook on Hybrid's RTL pattern

### DIFF
--- a/cerberus-hybrid.html
+++ b/cerberus-hybrid.html
@@ -526,7 +526,7 @@
                         <div style="display:inline-block; margin: 0 -1px; max-width: 220px; min-width:160px; vertical-align:top; width:100%;" class="stack-column">
                             <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%">
                                 <tr>
-                                    <td dir="ltr" style="padding: 10px 20px;">
+                                    <td dir="ltr" style="padding: 10px 0 10px 20px;">
                                         <img src="https://via.placeholder.com/200" width="200" height="" border="0" alt="alt_text" class="center-on-narrow" style="width: 100%; max-width: 200px; height: auto; background: #dddddd; font-family: sans-serif; font-size: 15px; line-height: 15px; color: #555555;">
                                     </td>
                                 </tr>
@@ -589,7 +589,7 @@
                         <div style="display:inline-block; margin: 0 -1px; max-width: 460px; min-width:280px; vertical-align:top;" class="stack-column">
                             <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%">
                                 <tr>
-                                    <td dir="ltr" style="font-family: sans-serif; font-size: 15px; line-height: 20px; color: #555555; padding: 10px 20px; text-align: left;" class="center-on-narrow">
+                                    <td dir="ltr" style="font-family: sans-serif; font-size: 15px; line-height: 20px; color: #555555; padding: 10px 0 10px 20px; text-align: left;" class="center-on-narrow">
                                         <h2 style="margin: 0 0 10px 0; font-family: sans-serif; font-size: 18px; line-height: 22px; color: #333333; font-weight: bold;">Class aptent taciti sociosqu</h2>
                                         <p style="margin: 0 0 10px 0;">Maecenas sed ante pellentesque, posuere leo id, eleifend dolor. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos.</p>
                                         <!-- Button : BEGIN -->

--- a/cerberus-hybrid.html
+++ b/cerberus-hybrid.html
@@ -567,16 +567,16 @@
                 <!-- Thumbnail Right, Text Left : BEGIN -->
                 <tr>
                     <!-- dir=rtl is where the magic happens. This can be changed to dir=ltr to swap the alignment on wide while maintaining stack order on narrow. -->
-                    <td dir="rtl" height="100%" valign="top" width="100%" style="font-size:0; padding: 10px; text-align: left; background-color: #ffffff;" class="darkmode-bg">
+                    <td dir="rtl" height="100%" valign="top" width="100%" style="font-size:0; padding: 10px 0; text-align: left; background-color: #ffffff;" class="darkmode-bg">
                         <!--[if mso]>
-                        <table role="presentation" border="0" cellspacing="0" cellpadding="0" width="660" style="width: 660px;">
+                        <table role="presentation" border="0" cellspacing="0" cellpadding="0" width="680">
                         <tr>
-                        <td valign="top" width="220" style="width: 220px;">
+                        <td valign="top" width="220">
                         <![endif]-->
                         <div style="display:inline-block; margin: 0 -1px; max-width: 220px; min-width:160px; vertical-align:top; width:100%;" class="stack-column">
                             <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%">
                                 <tr>
-                                    <td dir="ltr" style="padding: 0 10px 10px 10px;">
+                                    <td dir="ltr" style="padding: 10px 20px;">
                                         <img src="https://via.placeholder.com/200" width="200" height="" border="0" alt="alt_text" class="center-on-narrow" style="width: 100%; max-width: 200px; height: auto; background: #dddddd; font-family: sans-serif; font-size: 15px; line-height: 15px; color: #555555;">
                                     </td>
                                 </tr>
@@ -584,12 +584,12 @@
                         </div>
                         <!--[if mso]>
                         </td>
-                        <td valign="top" width="440" style="width: 440px;">
+                        <td valign="top" width="460">
                         <![endif]-->
-                        <div style="display:inline-block; margin: 0 -1px; max-width: 440px; min-width:280px; vertical-align:top;" class="stack-column">
+                        <div style="display:inline-block; margin: 0 -1px; max-width: 460px; min-width:280px; vertical-align:top;" class="stack-column">
                             <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%">
                                 <tr>
-                                    <td dir="ltr" style="font-family: sans-serif; font-size: 15px; line-height: 20px; color: #555555; padding: 10px 10px 0; text-align: left;" class="center-on-narrow">
+                                    <td dir="ltr" style="font-family: sans-serif; font-size: 15px; line-height: 20px; color: #555555; padding: 10px 20px; text-align: left;" class="center-on-narrow">
                                         <h2 style="margin: 0 0 10px 0; font-family: sans-serif; font-size: 18px; line-height: 22px; color: #333333; font-weight: bold;">Class aptent taciti sociosqu</h2>
                                         <p style="margin: 0 0 10px 0;">Maecenas sed ante pellentesque, posuere leo id, eleifend dolor. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos.</p>
                                         <!-- Button : BEGIN -->

--- a/cerberus-hybrid.html
+++ b/cerberus-hybrid.html
@@ -517,16 +517,16 @@
                 <!-- Thumbnail Left, Text Right : BEGIN -->
                 <tr>
                     <!-- dir=ltr is where the magic happens. This can be changed to dir=rtl to swap the alignment on wide while maintaining stack order on narrow. -->
-                    <td dir="ltr" height="100%" valign="top" width="100%" style="font-size:0; padding: 10px; background-color: #ffffff;" class="darkmode-bg">
+                    <td dir="ltr" height="100%" valign="top" width="100%" style="font-size:0; padding: 10px 0; text-align: left; background-color: #ffffff;" class="darkmode-bg">
                         <!--[if mso]>
-                        <table role="presentation" border="0" cellspacing="0" cellpadding="0" width="660" style="width: 660px;">
+                        <table role="presentation" border="0" cellspacing="0" cellpadding="0" width="680">
                         <tr>
-                        <td valign="top" width="220" style="width: 220px;">
+                        <td valign="top" width="220">
                         <![endif]-->
                         <div style="display:inline-block; margin: 0 -1px; max-width: 220px; min-width:160px; vertical-align:top; width:100%;" class="stack-column">
                             <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%">
                                 <tr>
-                                    <td dir="ltr" style="padding: 0 10px 10px 10px;">
+                                    <td dir="ltr" style="padding: 10px 20px;">
                                         <img src="https://via.placeholder.com/200" width="200" height="" border="0" alt="alt_text" class="center-on-narrow" style="width: 100%; max-width: 200px; height: auto; background: #dddddd; font-family: sans-serif; font-size: 15px; line-height: 15px; color: #555555;">
                                     </td>
                                 </tr>
@@ -534,12 +534,12 @@
                         </div>
                         <!--[if mso]>
                         </td>
-                        <td valign="top" width="440" style="width: 440px;">
+                        <td valign="top" width="460">
                         <![endif]-->
-                        <div style="display:inline-block; margin: 0 -1px; max-width: 440px; min-width:280px; vertical-align:top;" class="stack-column">
+                        <div style="display:inline-block; margin: 0 -1px; max-width: 460px; min-width:280px; vertical-align:top;" class="stack-column">
                             <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%">
                                 <tr>
-                                    <td dir="ltr" style="font-family: sans-serif; font-size: 15px; line-height: 20px; color: #555555; padding: 10px 10px 0; text-align: left;" class="center-on-narrow">
+                                    <td dir="ltr" style="font-family: sans-serif; font-size: 15px; line-height: 20px; color: #555555; padding: 10px 20px; text-align: left;" class="center-on-narrow">
                                         <h2 style="margin: 0 0 10px 0; font-family: sans-serif; font-size: 18px; line-height: 22px; color: #333333; font-weight: bold;">Class aptent taciti sociosqu</h2>
                                         <p style="margin: 0 0 10px 0;">Maecenas sed ante pellentesque, posuere leo id, eleifend dolor. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos.</p>
                                         <!-- Button : BEGIN -->


### PR DESCRIPTION
Resolves #248 

Using a [a tip](https://github.com/TedGoas/Cerberus/issues/248#issuecomment-1021894461) from @antoinegadp as a staring point, removing the padding from the outer-most container in the `rtl` pattern removes the border in Outlook on Windows.

Even though the `ltr` pattern did not have this same issue, I rewrote this pattern as well so the HTML/CSS matches that of the `rtl` pattern.

<img width="856" alt="Screen Shot 2022-02-27 at 2 26 31 PM" src="https://user-images.githubusercontent.com/1172461/155896843-e591090d-deb6-4f23-b4a1-221943bea21e.png">