### PR TITLE
Fix: duplicated text on best-practices page

### DIFF
--- a/docs/content/best-practices.md
+++ b/docs/content/best-practices.md
@@ -8,7 +8,7 @@ page_id = "best-practices"
 
 # Best Practices
 
-[Emails don’t need to look the same in every email client](http://doemailshavetolookthesameineveryclient.com/), Emails don’t need to look the same in every email client, but there are some guidelines to make sure they render properly in email clients and are as accessible as possible.
+[Emails don’t need to look the same in every email client](http://doemailshavetolookthesameineveryclient.com/), but there are some guidelines to make sure they render properly in email clients and are as accessible as possible.
 
 ## General rules and principles
 


### PR DESCRIPTION
Hi! I've noticed that there's little piece of text duplicated on Best Practices page (one has a link and the other one doesn't). I'm not sure if this change will affect the website itself beyond the .md file here in Github... I'd be glad if you could clarify that for me. Thank you!