### PR TITLE
best-practices.md: Warn about Outlook breaking font style inheritence when using tables

### DIFF
--- a/docs/content/best-practices.md
+++ b/docs/content/best-practices.md
@@ -27,12 +27,13 @@ That means:
 
 1. **Use `<table border="0" cellpadding="0" cellspacing="0" role="presentation">` when creating new tables.** This negates any unwanted spacing and borders and tells screen readers to skip over the table’s tags and move straight into the content.
 2. **When in doubt, nest another table.** For finer control of your HTML, nest tables when building emails.
-3. **Use padding for spacing in table cells.** Margins aren’t fully supported on tables and container elements.
-4. **Use margin for typography.** Margins *are* fully supported for headlines, paragraphs, and lists.
-5. **Use `align` for layout instead of `float`, `grid`, or `flexbox`.** Floats aren’t supported in Outlook and email clients don’t have good support for modern CSS layout properties in general.
-6. **HTML attributes are still relevant.** Most styling is done using CSS. But because some email clients use antiquated rendering engines, they tend to better understand HTML attributes like `align`, `valign`, `height`, and `width`.
-7. **Define color as `#ffffff` instead of `#fff` or `rgb(1,2,3)`.** Six-digit hex is supported in inline CSS as well as HTML attributes like `bgcolor` that are still supported in email.
-8. **Don’t forget about [preview text](https://stackoverflow.design/email/guidelines/faq#what-is-preview-text?).** We can specify the text that appears beneath subject lines in many email clients. If preview text is not included, this space will be populated by the email’s content.
+3. **Each `<td>` that contains text should have basic font properties inlined.** Do not rely on inheritance from parent elements for `font-family`, `font-size`, `font-weight`, `line-height` and `color` properties. Outlook on Windows is known to reset these properties to values from `<body>` every time you nest text in another table.
+4. **Use padding for spacing in table cells.** Margins aren’t fully supported on tables and container elements.
+5. **Use margin for typography.** Margins *are* fully supported for headlines, paragraphs, and lists.
+6. **Use `align` for layout instead of `float`, `grid`, or `flexbox`.** Floats aren’t supported in Outlook and email clients don’t have good support for modern CSS layout properties in general.
+7. **HTML attributes are still relevant.** Most styling is done using CSS. But because some email clients use antiquated rendering engines, they tend to better understand HTML attributes like `align`, `valign`, `height`, and `width`.
+8. **Define color as `#ffffff` instead of `#fff` or `rgb(1,2,3)`.** Six-digit hex is supported in inline CSS as well as HTML attributes like `bgcolor` that are still supported in email.
+9. **Don’t forget about [preview text](https://stackoverflow.design/email/guidelines/faq#what-is-preview-text?).** We can specify the text that appears beneath subject lines in many email clients. If preview text is not included, this space will be populated by the email’s content.
 
 ## Images
 

--- a/docs/content/best-practices.md
+++ b/docs/content/best-practices.md
@@ -27,7 +27,7 @@ That means:
 
 1. **Use `<table border="0" cellpadding="0" cellspacing="0" role="presentation">` when creating new tables.** This negates any unwanted spacing and borders and tells screen readers to skip over the table’s tags and move straight into the content.
 2. **When in doubt, nest another table.** For finer control of your HTML, nest tables when building emails.
-3. **Inline values of "inherited by default" CSS properties in `<td>` elements.** Do not rely on [default CSS inheritance](https://web.dev/learn/css/inheritance#which_properties_are_inherited_by_default) from parent elements for properties like `font-family`, `font-size`, `font-weight`, `line-height`, `color` etc. Outlook on Windows is known to reset these properties to values from `<body>` every time you nest text in another table.
+3. **Don't rely on CSS inheritance.** Some versions of Windows Outlook reset CSS properties `font-family`, `font-size`, `font-weight`, `line-height`, `color` from parent elements from `<body>` when nesting tables.
 4. **Use padding for spacing in table cells.** Margins aren’t fully supported on tables and container elements.
 5. **Use margin for typography.** Margins *are* fully supported for headlines, paragraphs, and lists.
 6. **Use `align` for layout instead of `float`, `grid`, or `flexbox`.** Floats aren’t supported in Outlook and email clients don’t have good support for modern CSS layout properties in general.

--- a/docs/content/best-practices.md
+++ b/docs/content/best-practices.md
@@ -27,7 +27,7 @@ That means:
 
 1. **Use `<table border="0" cellpadding="0" cellspacing="0" role="presentation">` when creating new tables.** This negates any unwanted spacing and borders and tells screen readers to skip over the table’s tags and move straight into the content.
 2. **When in doubt, nest another table.** For finer control of your HTML, nest tables when building emails.
-3. **Inline "inherited by default" CSS properties in `<td>` elements.** Do not rely on [default CSS inheritance](https://web.dev/learn/css/inheritance#which_properties_are_inherited_by_default) from parent elements for properties like `font-family`, `font-size`, `font-weight`, `line-height`, `color` etc. Outlook on Windows is known to reset these properties to values from `<body>` every time you nest text in another table.
+3. **Inline values of "inherited by default" CSS properties in `<td>` elements.** Do not rely on [default CSS inheritance](https://web.dev/learn/css/inheritance#which_properties_are_inherited_by_default) from parent elements for properties like `font-family`, `font-size`, `font-weight`, `line-height`, `color` etc. Outlook on Windows is known to reset these properties to values from `<body>` every time you nest text in another table.
 4. **Use padding for spacing in table cells.** Margins aren’t fully supported on tables and container elements.
 5. **Use margin for typography.** Margins *are* fully supported for headlines, paragraphs, and lists.
 6. **Use `align` for layout instead of `float`, `grid`, or `flexbox`.** Floats aren’t supported in Outlook and email clients don’t have good support for modern CSS layout properties in general.

--- a/docs/content/best-practices.md
+++ b/docs/content/best-practices.md
@@ -27,7 +27,7 @@ That means:
 
 1. **Use `<table border="0" cellpadding="0" cellspacing="0" role="presentation">` when creating new tables.** This negates any unwanted spacing and borders and tells screen readers to skip over the table’s tags and move straight into the content.
 2. **When in doubt, nest another table.** For finer control of your HTML, nest tables when building emails.
-3. **Each `<td>` that contains text should have basic font properties inlined.** Do not rely on inheritance from parent elements for `font-family`, `font-size`, `font-weight`, `line-height` and `color` properties. Outlook on Windows is known to reset these properties to values from `<body>` every time you nest text in another table.
+3. **Inline "inherited by default" CSS properties in `<td>` elements.** Do not rely on [default CSS inheritance](https://web.dev/learn/css/inheritance#which_properties_are_inherited_by_default) from parent elements for properties like `font-family`, `font-size`, `font-weight`, `line-height`, `color` etc. Outlook on Windows is known to reset these properties to values from `<body>` every time you nest text in another table.
 4. **Use padding for spacing in table cells.** Margins aren’t fully supported on tables and container elements.
 5. **Use margin for typography.** Margins *are* fully supported for headlines, paragraphs, and lists.
 6. **Use `align` for layout instead of `float`, `grid`, or `flexbox`.** Floats aren’t supported in Outlook and email clients don’t have good support for modern CSS layout properties in general.


### PR DESCRIPTION
It took me more time than I would like to admit until I realized that I should always copy font styles to `<td>` elements.

It is mentioned for example in [Email Coding Guidelines](https://gist.github.com/janogarcia/4977a2346cbc7e52334b#typography) by @janogarcia: 
> You can’t rely on table cells inheriting styles from a parent.

I checked [the code of the Fluid Template](https://raw.githubusercontent.com/TedGoas/Cerberus/main/cerberus-fluid.html) and it seems to adhere to this rule but I did not find it mentioned anywhere in the documentation.

The following code can be used to verify the behavior in Outlook (basically any version from 2007 to 365) on Windows (tested on Windows 10):
```
<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
        "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
<html xmlns="http://www.w3.org/1999/xhtml">
<head>
  <style>
    body {
      font-family: 'Times New Roman';
      font-size: 20px;
      color: #FF0000;
    }
  </style>
</head>
<body>
  <table>
    <tr>
      <td style="font-family: sans-serif; font-size: 30px; font-weight: 600; line-height: 50px; color: #0000FF;">
        This text has font family "sans-serif", font-size 30px, font-weight: 600,<br>
        line-height: 50px and blue color.
        
        <table>
          <tr>
            <td>
              This text should have same styles<br>
              but Outlook resets them to styles from body.
            </td>
          </tr>
        </table>

        <table>
          <tr>
            <td style="font-family: sans-serif; font-size: 30px; font-weight: 600; line-height: 50px; color: #0000FF;">
              This text has the same styles as the first text<br>
               because we inlined them and did not rely on inheritance.
            </td>
          </tr>
        </table>
      </td>
    </tr>
  </table>
</body>
</html>
```

Here is example how Outlook 2021 on Windows 10 renders it:
![image](https://github.com/TedGoas/Cerberus/assets/885946/64912be2-c808-4e8a-8102-fd6f0b513613)

I think it is important for this rule to be mentioned explicitly since the previous best practice advises to nest tables when in doubt.