### PR TITLE
Remove Cabin JS reference

### DIFF
--- a/docs/templates/index.html
+++ b/docs/templates/index.html
@@ -169,6 +169,5 @@
   </div>
   <script type='text/javascript' src='{{ get_url(path="scripts/scripts.js") | safe }}'></script>
   <script>hljs.highlightAll();</script>
-  <script async defer src="https://scripts.withcabin.com/hello.js"></script>
 </body>
 </html>


### PR DESCRIPTION
Removed the Cabin analytics JS reference, which has been disabled on Cabin.